### PR TITLE
Fix get connected tweet list scrollbar

### DIFF
--- a/src/components/TwitterChatter/_twitterchatter.scss
+++ b/src/components/TwitterChatter/_twitterchatter.scss
@@ -4,7 +4,6 @@
 
   @media (min-width: 672px) {
     max-height: 216px;
-    overflow: scroll;
   }
 }
 

--- a/src/components/TwitterChatter/_twitterchatter.scss
+++ b/src/components/TwitterChatter/_twitterchatter.scss
@@ -1,9 +1,24 @@
+@import 'carbon-components/scss/globals/scss/vars.scss';
+
 .tweet__list.bx--list--unordered {
   height: auto;
   overflow: auto;
 
   @media (min-width: 672px) {
     max-height: 216px;
+  }
+
+  &.tweet__list::-webkit-scrollbar {
+    width: 20px;
+  }
+
+  &.tweet__list::-webkit-scrollbar-thumb {
+    background: $inverse-02;
+    border-radius: 5px;
+  }
+
+  &.tweet__list::-webkit-scrollbar-thumb:hover {
+    background: $inverse-hover-ui;
   }
 }
 


### PR DESCRIPTION
We have fixed the horizontal scrollbar issue and changed the styling of the scrollbar.
Before:
![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/78379956/112204195-64cd2300-8be1-11eb-83c1-8ead7c55f56b.png)

After:
![MicrosoftTeams-image (106)](https://user-images.githubusercontent.com/78379956/112204229-6eef2180-8be1-11eb-8f9e-c0e8c2156d08.png)
 
Please note the vertical scrollbar styling doesn't show in Mozilla Firefox due to the vendor prefix applied. Currently, they don't support this feature.
Link : https://www.w3schools.com/howto/howto_css_custom_scrollbar.asp
